### PR TITLE
Properly handle redirected links, enable debug logging for raw input mode

### DIFF
--- a/guest_net_auth.py
+++ b/guest_net_auth.py
@@ -26,7 +26,7 @@ class TubitLogin():
     def __init__(self, usr, pw):
         self.usr, self.pw = usr, pw
         url_and_session = requests.get('http://www.heise.de', verify=False)
-        if url_and_session.url.endswith("www.heise.de/"):
+        if url_and_session.url.endswith("www.heise.de/") and not "redirect" in url_and_session.url:
             logging.info('Already logged in')
             self.success = True
             return
@@ -163,6 +163,7 @@ if __name__ == '__main__':
         import getpass
         usr = raw_input('Tubit-Username: ')
         pw = getpass.getpass('Tubit-Pw:  ')
+        logging.basicConfig(level=logging.DEBUG)
     else:
         with open(argv[1]) as f:
             usr, pw = f.read().split('\n')[:2]


### PR DESCRIPTION
The redirected page currently also ends in `www.heise.de/`:

```
DEBUG:urllib3.connectionpool:https://ise-01.tubit.tu-berlin.de:8443 "GET /portal/gateway?sessionId=AC19A00B00056D90ED7CC2C7&portal=168d10f0-2a1d-11e5-a6ef-005056b9670f&
action=cwa&token=cf859ca328e9cb373b800d3317f47d70&redirect=http://www.heise.de/ HTTP/1.1" 404 None
```

so guest_net_auth considers you always logged in. I also took the liberty to enable the logging for interactive authentication since -v only works with file input.